### PR TITLE
Add Permission rule to Registration Tests

### DIFF
--- a/app/src/androidTest/java/com/adammcneilly/espressopatronum/RegistrationTests.kt
+++ b/app/src/androidTest/java/com/adammcneilly/espressopatronum/RegistrationTests.kt
@@ -1,6 +1,9 @@
 package com.adammcneilly.espressopatronum
 
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.support.test.rule.ActivityTestRule
+import android.support.test.rule.GrantPermissionRule
 import android.support.test.runner.AndroidJUnit4
 import com.adammcneilly.espressopatronum.TestUtils.setFailureHandler
 import com.squareup.spoon.SpoonRule
@@ -19,6 +22,10 @@ class RegistrationTests {
     @Rule
     val rule: ActivityTestRule<MainActivity> = ActivityTestRule(MainActivity::class.java)
 
+    @JvmField
+    @Rule
+    val mPermissionsRule = GrantPermissionRule.grant(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE)
+    
     @JvmField
     @Rule
     val spoon: SpoonRule = SpoonRule()


### PR DESCRIPTION
## Issue:
When I run RegistrationTests from Android Studio run button on my Pixel device (running Android 8.1) I get error:
`java.lang.RuntimeException: Unable to create output dir: /storage/emulated/0/app_spoon-screenshots`

[screen shot ](https://user-images.githubusercontent.com/8283868/39496705-7d34f2b6-4d54-11e8-8b31-d106c7c93ee3.png)

## Fix:
Fixed by adding Permission Rule to RegistrationTests

   ``` @Rule
    var mPermissionsRule = GrantPermissionRule.grant(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE) 
```

PR fixes this git [issue](https://github.com/AdamMc331/EspressoPatronum/issues/1)

